### PR TITLE
feat: add status column to subscriptions and create subscription_tokens table

### DIFF
--- a/migrations/20250327153728_create_subscriptions_table.sql
+++ b/migrations/20250327153728_create_subscriptions_table.sql
@@ -1,4 +1,3 @@
--- Add migration script here
 -- subscriptions 테이블 생성
 -- set DATABASE_URL=postgres://postgres:password@127.0.0.1:5432/newsletter
 -- 위 명령어로 주소 설정하고

--- a/migrations/20250417105816_add_status_to_subscriptions.sql
+++ b/migrations/20250417105816_add_status_to_subscriptions.sql
@@ -1,0 +1,1 @@
+ALTER TABLE subscriptions ADD COLUMN status text NULL;

--- a/migrations/20250417110204_make_status_not_null_in_subscriptions.sql
+++ b/migrations/20250417110204_make_status_not_null_in_subscriptions.sql
@@ -1,0 +1,7 @@
+BEGIN;
+
+UPDATE subscriptions
+    SET status = 'confirmed' WHERE status IS NULL;
+
+    ALTER TABLE subscriptions ALTER COLUMN status SET NOT NULL;
+COMMIT;

--- a/migrations/20250417112115_create_subscription_token_table.sql
+++ b/migrations/20250417112115_create_subscription_token_table.sql
@@ -1,0 +1,5 @@
+CREATE TABLE subscription_tokens(
+    subscription_token TEXT NOT NULL,
+    subscriber_id uuid NOT NULL REFERENCES subscriptions (id),
+    PRIMARY KEY (subscription_token)
+);

--- a/src/routes/subscriptions.rs
+++ b/src/routes/subscriptions.rs
@@ -51,8 +51,8 @@ pub async fn insert_subscriber(
 ) -> Result<(), sqlx::Error> {
     sqlx::query!(
         r#"
-        INSERT INTO subscriptions (id, email, name, subscribed_at)
-        VALUES ($1, $2, $3, $4)
+        INSERT INTO subscriptions (id, email, name, subscribed_at, status)
+        VALUES ($1, $2, $3, $4, 'confirmed')
         "#,
         Uuid::new_v4(),
         new_subscriber.email.as_ref(),


### PR DESCRIPTION
무중단 배포를 위한 db 마이그레이션

실행했던 명령 command

```shell
sqlx migrate add add_status_to_subscriptions

sqlx migrate add make_status_not_null_in_subscriptions

sqlx migrate add create_subscription_tokens_table
```

sql 스크립트 작성한 후 ./scripts/init_db.sh 를 실행해도 되지만 

```shell
sqlx migrate run
```
해줘도 된다. 