### PR TITLE
최초 사용자 생성 및 미들웨어 도입하여 /admin 경로 핸들링

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -220,6 +220,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "actix-web-lab"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a33034dd88446a5deb20e42156dbfe43d07e0499345db3ae65b3f51854190531"
+dependencies = [
+ "actix-http",
+ "actix-router",
+ "actix-service",
+ "actix-utils",
+ "actix-web",
+ "actix-web-lab-derive",
+ "ahash 0.8.11",
+ "arc-swap",
+ "bytes",
+ "bytestring",
+ "csv",
+ "derive_more 2.0.1",
+ "form_urlencoded",
+ "futures-core",
+ "futures-util",
+ "http 0.2.12",
+ "impl-more",
+ "itertools",
+ "local-channel",
+ "mime",
+ "pin-project-lite",
+ "regex",
+ "serde",
+ "serde_html_form",
+ "serde_json",
+ "serde_path_to_error",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "actix-web-lab-derive"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd80fa0bd6217e482112d9d87a05af8e0f8dec9e3aa51f34816f761c5cf7da7"
+dependencies = [
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
 name = "addr2line"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -736,6 +784,27 @@ dependencies = [
  "generic-array",
  "rand_core 0.6.4",
  "typenum",
+]
+
+[[package]]
+name = "csv"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdc4883a9c96732e4733212c01447ebd805833b7275a73ca3ee080fd77afdaf"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d02f3b0da4c6504f86e9cd789d8dbafab48c2321be74e9987593de5a894d93d"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1657,6 +1726,15 @@ name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -2613,6 +2691,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_html_form"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d2de91cf02bbc07cde38891769ccd5d4f073d22a40683aa4bc7a95781aaa2c4"
+dependencies = [
+ "form_urlencoded",
+ "indexmap 2.8.0",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "serde_json"
 version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2621,6 +2712,16 @@ dependencies = [
  "itoa",
  "memchr",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59fab13f937fa393d08645bf3a84bdfe86e296747b506ada67bb15f10f218b2a"
+dependencies = [
+ "itoa",
  "serde",
 ]
 
@@ -3838,6 +3939,7 @@ dependencies = [
  "actix-session",
  "actix-web",
  "actix-web-flash-messages",
+ "actix-web-lab",
  "anyhow",
  "argon2",
  "base64 0.13.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ argon2 = { version = "0.4", features = ["std"] }
 actix-web-flash-messages = { version = "0.5", features = ["cookies"] }
 actix-session = { version = "0.10", features = ["redis-session"] }
 serde_json = "1"
+actix-web-lab = "0.24"
 
 # Dev 디펜더시는 테스트를 실행할 때만 사용되고 최종 애플리케이션 바이너리에는 포함되지 않음.
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -423,5 +423,12 @@ OWASP 가이드라인에 따르면 신뢰할 수 없는 입력을 HTML 엔티티
 * 사용자가 확인 링크를 두 번 클릭하면 어떻게 되나
 * 구독 토큰의 형태는 적절하지만 토큰이 실제로는 존재하지 않는다면,
 * 유입되는 토큰에 대해 검증하기, 현재 사용자의 입력을 그대로 쿼리에 전달하고 있다. (다행이도 sqlx에서 sql 인젝션을 방지해준다.)
+* 관리자 대시보드에 send a newsletter issue 링크를 추가한다.
+* GET /admin/newsletters에 새로운 이슈를 제출하는 HTML 폼을 추가한다.
+* POST /newsletter가 그 폼 데이터를 처리하게 수정한다.
+  * 경로를 POST /admin/newsletter로 변경한다.
+  * 기본 인증을 세션 기반 인증으로 마이그레이션한다.
+  * Json 추출기(application/json) 대신 Form 추출기(application/x-www-form-urlencoded)를 사용해서 요청 바디를 처리한다.
+  * 테스트 스위트를 수정한다.
 
 [깃허브 저장소](https://github.com/LukeMathWalker/zero-to-production)

--- a/migrations/20250608040221_seed_user.sql
+++ b/migrations/20250608040221_seed_user.sql
@@ -1,0 +1,4 @@
+INSERT INTO users (user_id, username, password_hash)
+VALUES ('ddf8994f-d522-4659-8d02-c1d479057be6',
+        'admin',
+        '$argon2id$v=19$m=15000,t=2,p=1$OEx/rcq+3ts//WUDzGNl2g$Am8UFBA4w5NJEmAtquGvBmAlu92q/VQcaoL5AyJPfc8');

--- a/src/authentication.rs
+++ b/src/authentication.rs
@@ -1,6 +1,7 @@
 use crate::telemetry::spawn_blocking_with_tracing;
 use anyhow::Context;
-use argon2::{Argon2, PasswordHash, PasswordVerifier};
+use argon2::password_hash::SaltString;
+use argon2::{Algorithm, Argon2, Params, PasswordHash, PasswordHasher, PasswordVerifier, Version};
 use secrecy::{ExposeSecret, Secret};
 use sqlx::PgPool;
 
@@ -86,4 +87,39 @@ fn verify_password_hash(
         )
         .context("Invalid password")
         .map_err(AuthError::InvalidCredentials)
+}
+
+pub async fn change_password(
+    user_id: uuid::Uuid,
+    password: Secret<String>,
+    pool: &PgPool,
+) -> Result<(), anyhow::Error> {
+    let password_hash = spawn_blocking_with_tracing(move || compute_password_hash(password))
+        .await?
+        .context("Failed to hash password")?;
+    sqlx::query!(
+        r#"
+        UPDATE users
+        SET password_hash = $1
+        WHERE user_id = $2
+        "#,
+        password_hash.expose_secret(),
+        user_id,
+    )
+    .execute(pool)
+    .await
+    .context("Failed to change user's password in the database")?;
+    Ok(())
+}
+
+fn compute_password_hash(password: Secret<String>) -> Result<Secret<String>, anyhow::Error> {
+    let salt = SaltString::generate(&mut rand::thread_rng());
+    let password_hash = Argon2::new(
+        Algorithm::Argon2id,
+        Version::V0x13,
+        Params::new(15000, 2, 1, None).unwrap(),
+    )
+    .hash_password(password.expose_secret().as_bytes(), &salt)?
+    .to_string();
+    Ok(Secret::new(password_hash))
 }

--- a/src/authentication/middleware.rs
+++ b/src/authentication/middleware.rs
@@ -1,0 +1,48 @@
+use crate::session_state::TypedSession;
+use crate::utils::{e500, see_other};
+use actix_web::body::MessageBody;
+use actix_web::dev::{ServiceRequest, ServiceResponse};
+use actix_web::error::InternalError;
+use actix_web::middleware::Next;
+use actix_web::{FromRequest, HttpMessage};
+use std::ops::Deref;
+use uuid::Uuid;
+
+#[derive(Copy, Clone, Debug)]
+pub struct UserId(Uuid);
+
+impl std::fmt::Display for UserId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl Deref for UserId {
+    type Target = Uuid;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+pub async fn reject_anonymous_users(
+    mut req: ServiceRequest,
+    next: Next<impl MessageBody>,
+) -> Result<ServiceResponse<impl MessageBody>, actix_web::Error> {
+    let session = {
+        let (http_request, payload) = req.parts_mut();
+        TypedSession::from_request(http_request, payload).await
+    }?;
+
+    match session.get_user_id().map_err(e500)? {
+        None => {
+            let response = see_other("/login");
+            let e = anyhow::anyhow!("The user has not logged in");
+            Err(InternalError::from_response(e, response).into())
+        }
+        Some(user_id) => {
+            req.extensions_mut().insert(UserId(user_id));
+            next.call(req).await
+        }
+    }
+}

--- a/src/authentication/mod.rs
+++ b/src/authentication/mod.rs
@@ -1,0 +1,5 @@
+mod middleware;
+mod password;
+
+pub use middleware::{UserId, reject_anonymous_users};
+pub use password::{AuthError, Credentials, change_password, validate_credentials};

--- a/src/authentication/password.rs
+++ b/src/authentication/password.rs
@@ -41,8 +41,8 @@ pub async fn validate_credentials(
     spawn_blocking_with_tracing(move || {
         verify_password_hash(expected_password_hash, credentials.password)
     })
-    .await
-    .context("Failed to spawn blocking task")??;
+        .await
+        .context("Failed to spawn blocking task")??;
 
     user_id
         .ok_or_else(|| anyhow::anyhow!("Unknown username"))
@@ -62,10 +62,10 @@ async fn get_stored_credentials(
         "#,
         username,
     )
-    .fetch_optional(pool)
-    .await
-    .context("Failed to perform a query to retrieve stored credentials.")?
-    .map(|row| (row.user_id, Secret::new(row.password_hash)));
+        .fetch_optional(pool)
+        .await
+        .context("Failed to perform a query to retrieve stored credentials.")?
+        .map(|row| (row.user_id, Secret::new(row.password_hash)));
     Ok(row)
 }
 
@@ -106,9 +106,9 @@ pub async fn change_password(
         password_hash.expose_secret(),
         user_id,
     )
-    .execute(pool)
-    .await
-    .context("Failed to change user's password in the database")?;
+        .execute(pool)
+        .await
+        .context("Failed to change user's password in the database")?;
     Ok(())
 }
 
@@ -119,7 +119,7 @@ fn compute_password_hash(password: Secret<String>) -> Result<Secret<String>, any
         Version::V0x13,
         Params::new(15000, 2, 1, None).unwrap(),
     )
-    .hash_password(password.expose_secret().as_bytes(), &salt)?
-    .to_string();
+        .hash_password(password.expose_secret().as_bytes(), &salt)?
+        .to_string();
     Ok(Secret::new(password_hash))
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,3 +6,4 @@ pub mod routes;
 pub mod session_state;
 pub mod startup;
 pub mod telemetry;
+pub mod utils;

--- a/src/routes/admin/dashboard.rs
+++ b/src/routes/admin/dashboard.rs
@@ -29,6 +29,15 @@ pub async fn admin_dashboard(
 
             <body>
             <p>Welcome {username}!</p>
+            <p>Available actions:</p>
+    <ol>
+        <li><a href="/admin/password">Change password</a></li>
+        <li>
+          <form name="logoutForm" action="/admin/logout" method="post">
+            <input type="submit" value="Logout">
+          </form>
+        </li>
+    </ol>
             </body>
             </html>
             "#

--- a/src/routes/admin/dashboard.rs
+++ b/src/routes/admin/dashboard.rs
@@ -36,7 +36,7 @@ pub async fn admin_dashboard(
 }
 
 #[tracing::instrument(name = "Get username", skip(pool))]
-async fn get_username(user_id: Uuid, pool: &PgPool) -> Result<String, anyhow::Error> {
+pub async fn get_username(user_id: Uuid, pool: &PgPool) -> Result<String, anyhow::Error> {
     let row = sqlx::query!(
         r#"
         SELECT username

--- a/src/routes/admin/dashboard.rs
+++ b/src/routes/admin/dashboard.rs
@@ -1,16 +1,10 @@
 use crate::session_state::TypedSession;
+use crate::utils::e500;
 use actix_web::http::header::{ContentType, LOCATION};
 use actix_web::{HttpResponse, web};
 use anyhow::Context;
 use sqlx::PgPool;
 use uuid::Uuid;
-
-fn e500<T>(e: T) -> actix_web::Error
-where
-    T: std::fmt::Debug + std::fmt::Display + 'static,
-{
-    actix_web::error::ErrorInternalServerError(e)
-}
 
 pub async fn admin_dashboard(
     session: TypedSession,

--- a/src/routes/admin/logout.rs
+++ b/src/routes/admin/logout.rs
@@ -1,0 +1,14 @@
+use crate::session_state::TypedSession;
+use crate::utils::{e500, see_other};
+use actix_web::HttpResponse;
+use actix_web_flash_messages::FlashMessage;
+
+pub async fn log_out(session: TypedSession) -> Result<HttpResponse, actix_web::Error> {
+    if session.get_user_id().map_err(e500)?.is_none() {
+        Ok(see_other("login"))
+    } else {
+        session.log_out();
+        FlashMessage::info("You have successfully logged out.").send();
+        Ok(see_other("/login"))
+    }
+}

--- a/src/routes/admin/mod.rs
+++ b/src/routes/admin/mod.rs
@@ -1,5 +1,7 @@
 mod dashboard;
+mod logout;
 mod password;
 
 pub use dashboard::admin_dashboard;
+pub use logout::log_out;
 pub use password::*;

--- a/src/routes/admin/mod.rs
+++ b/src/routes/admin/mod.rs
@@ -1,3 +1,5 @@
 mod dashboard;
+mod password;
 
 pub use dashboard::admin_dashboard;
+pub use password::*;

--- a/src/routes/admin/password/get.rs
+++ b/src/routes/admin/password/get.rs
@@ -1,0 +1,45 @@
+use crate::session_state::TypedSession;
+use crate::utils::{e500, see_other};
+use actix_web::HttpResponse;
+use actix_web::http::header::ContentType;
+
+pub async fn change_password_form(session: TypedSession) -> Result<HttpResponse, actix_web::Error> {
+    if session.get_user_id().map_err(e500)?.is_none() {
+        return Ok(see_other("/login"));
+    }
+
+    Ok(HttpResponse::Ok().content_type(ContentType::html()).body(
+        r#"
+        <!DOCTYPE html>
+        <html lang="en">
+        <head>
+        <meta http-equiv="content-type" content="text/html; charset=utf-8">
+        <title>Change Password</title>
+        </head>
+        <body>
+        <form action="/admin/password" method="post">
+        <label>Current Password
+        <input type="password"
+        placeholder="Enter current password"
+        name="new_password">
+        </label>
+        <br>
+        <label>New Password
+        <input type="password"
+        placeholder="Enter new password"
+        name="new_password">
+        </label>
+        <br>
+        <label>Confirm password
+        <input type="password"
+        placeholder="Type the new password again"
+        name="new_password_check">
+        </label>
+        <br>
+        <button type="submit">Change Password</button>
+        </form>
+        <p><a href="/admin/dashboard">&lt;- Back</a></p>
+        </body>
+        </html>"#,
+    ))
+}

--- a/src/routes/admin/password/get.rs
+++ b/src/routes/admin/password/get.rs
@@ -2,14 +2,26 @@ use crate::session_state::TypedSession;
 use crate::utils::{e500, see_other};
 use actix_web::HttpResponse;
 use actix_web::http::header::ContentType;
+use actix_web_flash_messages::IncomingFlashMessages;
+use std::fmt::Write;
 
-pub async fn change_password_form(session: TypedSession) -> Result<HttpResponse, actix_web::Error> {
+pub async fn change_password_form(
+    session: TypedSession,
+    flash_messages: IncomingFlashMessages,
+) -> Result<HttpResponse, actix_web::Error> {
     if session.get_user_id().map_err(e500)?.is_none() {
         return Ok(see_other("/login"));
     }
 
-    Ok(HttpResponse::Ok().content_type(ContentType::html()).body(
-        r#"
+    let mut msg_html = String::new();
+    for m in flash_messages.iter() {
+        writeln!(msg_html, "<p><i>{}</i></p>", m.content()).unwrap();
+    }
+
+    Ok(HttpResponse::Ok()
+        .content_type(ContentType::html())
+        .body(format!(
+            r#"
         <!DOCTYPE html>
         <html lang="en">
         <head>
@@ -17,6 +29,7 @@ pub async fn change_password_form(session: TypedSession) -> Result<HttpResponse,
         <title>Change Password</title>
         </head>
         <body>
+        {msg_html}
         <form action="/admin/password" method="post">
         <label>Current Password
         <input type="password"
@@ -41,5 +54,5 @@ pub async fn change_password_form(session: TypedSession) -> Result<HttpResponse,
         <p><a href="/admin/dashboard">&lt;- Back</a></p>
         </body>
         </html>"#,
-    ))
+        )))
 }

--- a/src/routes/admin/password/mod.rs
+++ b/src/routes/admin/password/mod.rs
@@ -1,0 +1,5 @@
+mod get;
+mod post;
+
+pub use get::change_password_form;
+pub use post::change_password;

--- a/src/routes/admin/password/post.rs
+++ b/src/routes/admin/password/post.rs
@@ -1,4 +1,4 @@
-use crate::authentication::{AuthError, Credentials, validate_credentials};
+use crate::authentication::{self, AuthError, Credentials, validate_credentials};
 use crate::routes::admin::dashboard::get_username;
 use crate::session_state::TypedSession;
 use crate::utils::{e500, see_other};
@@ -48,5 +48,9 @@ pub async fn change_password(
         };
     }
 
-    todo!()
+    authentication::change_password(user_id, form.0.new_password, &pool)
+        .await
+        .map_err(e500)?;
+    FlashMessage::error("Your password has been changed.").send();
+    Ok(see_other("/admin/password"))
 }

--- a/src/routes/admin/password/post.rs
+++ b/src/routes/admin/password/post.rs
@@ -1,0 +1,22 @@
+use crate::session_state::TypedSession;
+use crate::utils::{e500, see_other};
+use actix_web::{HttpResponse, web};
+use secrecy::Secret;
+
+#[derive(serde::Deserialize)]
+pub struct FormData {
+    current_password: Secret<String>,
+    new_password: Secret<String>,
+    new_password_check: Secret<String>,
+}
+
+pub async fn change_password(
+    form: web::Form<FormData>,
+    session: TypedSession,
+) -> Result<HttpResponse, actix_web::Error> {
+    if session.get_user_id().map_err(e500)?.is_none() {
+        return Ok(see_other("/login"));
+    };
+
+    todo!()
+}

--- a/src/routes/admin/password/post.rs
+++ b/src/routes/admin/password/post.rs
@@ -1,8 +1,11 @@
+use crate::authentication::{AuthError, Credentials, validate_credentials};
+use crate::routes::admin::dashboard::get_username;
 use crate::session_state::TypedSession;
 use crate::utils::{e500, see_other};
 use actix_web::{HttpResponse, web};
 use actix_web_flash_messages::FlashMessage;
 use secrecy::{ExposeSecret, Secret};
+use sqlx::PgPool;
 
 #[derive(serde::Deserialize)]
 pub struct FormData {
@@ -14,10 +17,13 @@ pub struct FormData {
 pub async fn change_password(
     form: web::Form<FormData>,
     session: TypedSession,
+    pool: web::Data<PgPool>,
 ) -> Result<HttpResponse, actix_web::Error> {
-    if session.get_user_id().map_err(e500)?.is_none() {
+    let user_id = session.get_user_id().map_err(e500)?;
+    if user_id.is_none() {
         return Ok(see_other("/login"));
     };
+    let user_id = user_id.unwrap();
 
     if form.new_password.expose_secret() != form.new_password_check.expose_secret() {
         FlashMessage::error(
@@ -25,6 +31,21 @@ pub async fn change_password(
         )
         .send();
         return Ok(see_other("/admin/password"));
+    }
+
+    let username = get_username(user_id, &pool).await.map_err(e500)?;
+    let credentials = Credentials {
+        username,
+        password: form.0.current_password,
+    };
+    if let Err(e) = validate_credentials(credentials, &pool).await {
+        return match e {
+            AuthError::InvalidCredentials(_) => {
+                FlashMessage::error("The current password is incorrect.").send();
+                Ok(see_other("/admin/password"))
+            }
+            AuthError::UnexpectedError(_) => Err(e500(e).into()),
+        };
     }
 
     todo!()

--- a/src/routes/admin/password/post.rs
+++ b/src/routes/admin/password/post.rs
@@ -2,10 +2,12 @@ use crate::authentication::{self, AuthError, Credentials, validate_credentials};
 use crate::routes::admin::dashboard::get_username;
 use crate::session_state::TypedSession;
 use crate::utils::{e500, see_other};
+use actix_web::error::InternalError;
 use actix_web::{HttpResponse, web};
 use actix_web_flash_messages::FlashMessage;
 use secrecy::{ExposeSecret, Secret};
 use sqlx::PgPool;
+use uuid::Uuid;
 
 #[derive(serde::Deserialize)]
 pub struct FormData {
@@ -14,16 +16,23 @@ pub struct FormData {
     new_password_check: Secret<String>,
 }
 
+async fn reject_anonymous_users(session: TypedSession) -> Result<Uuid, actix_web::Error> {
+    match session.get_user_id().map_err(e500)? {
+        None => {
+            let response = see_other("/login");
+            let e = anyhow::anyhow!("The user has not logged in");
+            Err(InternalError::from_response(e, response).into())
+        }
+        Some(user_id) => Ok(user_id),
+    }
+}
+
 pub async fn change_password(
     form: web::Form<FormData>,
     session: TypedSession,
     pool: web::Data<PgPool>,
 ) -> Result<HttpResponse, actix_web::Error> {
-    let user_id = session.get_user_id().map_err(e500)?;
-    if user_id.is_none() {
-        return Ok(see_other("/login"));
-    };
-    let user_id = user_id.unwrap();
+    let user_id = reject_anonymous_users(session).await?;
 
     if form.new_password.expose_secret() != form.new_password_check.expose_secret() {
         FlashMessage::error(

--- a/src/routes/admin/password/post.rs
+++ b/src/routes/admin/password/post.rs
@@ -1,13 +1,10 @@
-use crate::authentication::{self, AuthError, Credentials, validate_credentials};
+use crate::authentication::{self, AuthError, Credentials, UserId, validate_credentials};
 use crate::routes::admin::dashboard::get_username;
-use crate::session_state::TypedSession;
 use crate::utils::{e500, see_other};
-use actix_web::error::InternalError;
 use actix_web::{HttpResponse, web};
 use actix_web_flash_messages::FlashMessage;
 use secrecy::{ExposeSecret, Secret};
 use sqlx::PgPool;
-use uuid::Uuid;
 
 #[derive(serde::Deserialize)]
 pub struct FormData {
@@ -16,23 +13,12 @@ pub struct FormData {
     new_password_check: Secret<String>,
 }
 
-async fn reject_anonymous_users(session: TypedSession) -> Result<Uuid, actix_web::Error> {
-    match session.get_user_id().map_err(e500)? {
-        None => {
-            let response = see_other("/login");
-            let e = anyhow::anyhow!("The user has not logged in");
-            Err(InternalError::from_response(e, response).into())
-        }
-        Some(user_id) => Ok(user_id),
-    }
-}
-
 pub async fn change_password(
     form: web::Form<FormData>,
-    session: TypedSession,
     pool: web::Data<PgPool>,
+    user_id: web::ReqData<UserId>,
 ) -> Result<HttpResponse, actix_web::Error> {
-    let user_id = reject_anonymous_users(session).await?;
+    let user_id = user_id.into_inner();
 
     if form.new_password.expose_secret() != form.new_password_check.expose_secret() {
         FlashMessage::error(
@@ -42,7 +28,7 @@ pub async fn change_password(
         return Ok(see_other("/admin/password"));
     }
 
-    let username = get_username(user_id, &pool).await.map_err(e500)?;
+    let username = get_username(*user_id, &pool).await.map_err(e500)?;
     let credentials = Credentials {
         username,
         password: form.0.current_password,
@@ -57,7 +43,7 @@ pub async fn change_password(
         };
     }
 
-    authentication::change_password(user_id, form.0.new_password, &pool)
+    authentication::change_password(*user_id, form.0.new_password, &pool)
         .await
         .map_err(e500)?;
     FlashMessage::error("Your password has been changed.").send();

--- a/src/routes/admin/password/post.rs
+++ b/src/routes/admin/password/post.rs
@@ -1,7 +1,8 @@
 use crate::session_state::TypedSession;
 use crate::utils::{e500, see_other};
 use actix_web::{HttpResponse, web};
-use secrecy::Secret;
+use actix_web_flash_messages::FlashMessage;
+use secrecy::{ExposeSecret, Secret};
 
 #[derive(serde::Deserialize)]
 pub struct FormData {
@@ -17,6 +18,14 @@ pub async fn change_password(
     if session.get_user_id().map_err(e500)?.is_none() {
         return Ok(see_other("/login"));
     };
+
+    if form.new_password.expose_secret() != form.new_password_check.expose_secret() {
+        FlashMessage::error(
+            "You entered two different new passwords - the field values must match.",
+        )
+        .send();
+        return Ok(see_other("/admin/password"));
+    }
 
     todo!()
 }

--- a/src/routes/login/get.rs
+++ b/src/routes/login/get.rs
@@ -1,11 +1,11 @@
 use actix_web::HttpResponse;
 use actix_web::http::header::ContentType;
-use actix_web_flash_messages::{IncomingFlashMessages, Level};
+use actix_web_flash_messages::IncomingFlashMessages;
 use std::fmt::Write;
 
 pub async fn login_form(flash_messages: IncomingFlashMessages) -> HttpResponse {
     let mut error_html = String::new();
-    for m in flash_messages.iter().filter(|m| m.level() == Level::Error) {
+    for m in flash_messages.iter() {
         writeln!(error_html, "<p><i>{}</i></p>", m.content()).unwrap();
     }
     HttpResponse::Ok()

--- a/src/session_state.rs
+++ b/src/session_state.rs
@@ -25,6 +25,10 @@ impl TypedSession {
             .get(Self::USER_ID_KEY)
             .map_err(|e| serde_json::Error::custom(e.to_string()))
     }
+
+    pub fn log_out(self) {
+        self.0.purge()
+    }
 }
 
 impl FromRequest for TypedSession {

--- a/src/startup.rs
+++ b/src/startup.rs
@@ -2,7 +2,7 @@ use crate::configuration::{DatabaseSettings, Settings};
 use crate::email_client::EmailClient;
 use crate::routes::{
     admin_dashboard, change_password, change_password_form, confirm, greet, health_check, home,
-    login, login_form, publish_newsletter, subscribe,
+    log_out, login, login_form, publish_newsletter, subscribe,
 };
 use actix_session::SessionMiddleware;
 use actix_session::storage::RedisSessionStore;
@@ -117,6 +117,7 @@ async fn run(
             .route("/admin/dashboard", web::get().to(admin_dashboard))
             .route("/admin/password", web::get().to(change_password_form))
             .route("/admin/password", web::post().to(change_password))
+            .route("/admin/logout", web::post().to(log_out))
             .app_data(db_pool.clone())
             .app_data(email_client.clone())
             .app_data(base_url.clone())

--- a/src/startup.rs
+++ b/src/startup.rs
@@ -1,3 +1,4 @@
+use crate::authentication::reject_anonymous_users;
 use crate::configuration::{DatabaseSettings, Settings};
 use crate::email_client::EmailClient;
 use crate::routes::{
@@ -8,6 +9,7 @@ use actix_session::SessionMiddleware;
 use actix_session::storage::RedisSessionStore;
 use actix_web::cookie::Key;
 use actix_web::dev::Server;
+use actix_web::middleware::from_fn;
 use actix_web::web::Data;
 use actix_web::{App, HttpServer, web};
 use actix_web_flash_messages::FlashMessagesFramework;
@@ -114,10 +116,14 @@ async fn run(
             .route("/subscriptions", web::post().to(subscribe))
             .route("/subscriptions/confirm", web::get().to(confirm))
             .route("/newsletters", web::post().to(publish_newsletter))
-            .route("/admin/dashboard", web::get().to(admin_dashboard))
-            .route("/admin/password", web::get().to(change_password_form))
-            .route("/admin/password", web::post().to(change_password))
-            .route("/admin/logout", web::post().to(log_out))
+            .service(
+                web::scope("/admin")
+                    .wrap(from_fn(reject_anonymous_users))
+                    .route("/dashboard", web::get().to(admin_dashboard))
+                    .route("/password", web::get().to(change_password_form))
+                    .route("/password", web::post().to(change_password))
+                    .route("/logout", web::post().to(log_out)),
+            )
             .app_data(db_pool.clone())
             .app_data(email_client.clone())
             .app_data(base_url.clone())

--- a/src/startup.rs
+++ b/src/startup.rs
@@ -1,8 +1,8 @@
 use crate::configuration::{DatabaseSettings, Settings};
 use crate::email_client::EmailClient;
 use crate::routes::{
-    admin_dashboard, confirm, greet, health_check, home, login, login_form, publish_newsletter,
-    subscribe,
+    admin_dashboard, change_password, change_password_form, confirm, greet, health_check, home,
+    login, login_form, publish_newsletter, subscribe,
 };
 use actix_session::SessionMiddleware;
 use actix_session::storage::RedisSessionStore;
@@ -115,6 +115,8 @@ async fn run(
             .route("/subscriptions/confirm", web::get().to(confirm))
             .route("/newsletters", web::post().to(publish_newsletter))
             .route("/admin/dashboard", web::get().to(admin_dashboard))
+            .route("/admin/password", web::get().to(change_password_form))
+            .route("/admin/password", web::post().to(change_password))
             .app_data(db_pool.clone())
             .app_data(email_client.clone())
             .app_data(base_url.clone())

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,15 @@
+use actix_web::HttpResponse;
+use actix_web::http::header::LOCATION;
+
+pub fn e500<T>(e: T) -> actix_web::Error
+where
+    T: std::fmt::Debug + std::fmt::Display + 'static,
+{
+    actix_web::error::ErrorInternalServerError(e)
+}
+
+pub fn see_other(location: &str) -> HttpResponse {
+    HttpResponse::SeeOther()
+        .insert_header((LOCATION, location))
+        .finish()
+}

--- a/tests/api/admin_dashboard.rs
+++ b/tests/api/admin_dashboard.rs
@@ -11,3 +11,34 @@ async fn you_must_be_logged_in_to_access_the_admin_dashboard() {
     // Assert
     assert_is_redirect_to(&response, "/login");
 }
+
+#[tokio::test]
+async fn logout_clears_session_state() {
+    // Arrange
+    let app = spawn_app().await;
+
+    // Act - Part 1 - 로그인한다.
+    let login_body = serde_json::json!({
+        "username": &app.test_user.username,
+        "password": &app.test_user.password
+    });
+
+    let response = app.post_login(&login_body).await;
+    assert_is_redirect_to(&response, "/admin/dashboard");
+
+    // Act - Part 2 - 리다이렉트를 따른다.
+    let html_page = app.get_admin_dashboard_html().await;
+    assert!(html_page.contains(&format!("Welcome {}", app.test_user.username)));
+
+    // Act - Part 3 - 로그아웃한다.
+    let response = app.post_logout().await;
+    assert_is_redirect_to(&response, "/login");
+
+    // Act - Part 4 - 리다이렉트를 따른다.
+    let html_page = app.get_login_html().await;
+    assert!(html_page.contains(r#"<p><i>You have successfully logged out.</i></p>"#));
+
+    // Act - Part 5 - 관리자 패널을 로딩한다.
+    let response = app.get_admin_dashboard().await;
+    assert_is_redirect_to(&response, "/login");
+}

--- a/tests/api/change_password.rs
+++ b/tests/api/change_password.rs
@@ -1,0 +1,33 @@
+use crate::helpers::{assert_is_redirect_to, spawn_app};
+use uuid::Uuid;
+
+#[tokio::test]
+async fn you_must_be_logged_in_to_see_the_change_password_form() {
+    // Arrange
+    let app = spawn_app().await;
+
+    // Act
+    let response = app.get_change_password().await;
+
+    // Assert
+    assert_is_redirect_to(&response, "/login");
+}
+
+#[tokio::test]
+async fn you_must_be_logged_in_to_change_your_password() {
+    // Arrange
+    let app = spawn_app().await;
+    let new_password = Uuid::new_v4().to_string();
+
+    // Act
+    let response = app
+        .post_change_password(&serde_json::json!({
+            "current_password": Uuid::new_v4().to_string(),
+            "new_password": &new_password,
+            "new_password_check": &new_password,
+        }))
+        .await;
+
+    // Assert
+    assert_is_redirect_to(&response, "/login");
+}

--- a/tests/api/change_password.rs
+++ b/tests/api/change_password.rs
@@ -31,3 +31,36 @@ async fn you_must_be_logged_in_to_change_your_password() {
     // Assert
     assert_is_redirect_to(&response, "/login");
 }
+
+#[tokio::test]
+async fn new_password_fields_must_match() {
+    // Arrange
+    let app = spawn_app().await;
+    let new_password = Uuid::new_v4().to_string();
+    let another_new_password = Uuid::new_v4().to_string();
+
+    // Act - Part 1 - 로그인
+    app.post_login(&serde_json::json!({
+        "username": &app.test_user.username,
+        "password": &app.test_user.password,
+    }))
+    .await;
+
+    // Act - Part 2 - 비밀번호 변경을 시도한다.
+    let response = app
+        .post_change_password(&serde_json::json!({
+            "current_password": &app.test_user.password,
+            "new_password": &new_password,
+            "new_password_check": &another_new_password,
+        }))
+        .await;
+
+    assert_is_redirect_to(&response, "/admin/password");
+
+    // Act - Part 3 - 리다이렉트를 따른다.
+    let html_page = app.get_change_password_html().await;
+
+    assert!(html_page.contains(
+        "<p><i>You entered two different new passwords - the field values must match.</i></p>"
+    ))
+}

--- a/tests/api/change_password.rs
+++ b/tests/api/change_password.rs
@@ -95,3 +95,48 @@ async fn current_password_must_be_valid() {
     let html_page = app.get_change_password_html().await;
     assert!(html_page.contains("<p><i>The current password is incorrect.</i></p>"));
 }
+
+#[tokio::test]
+async fn changing_password_works() {
+    // Arrange
+    let app = spawn_app().await;
+    let new_password = Uuid::new_v4().to_string();
+
+    // Act - Part 1 - 로그인한다.
+    let login_body = serde_json::json!({
+        "username": &app.test_user.username,
+        "password": &app.test_user.password,
+    });
+    let response = app.post_login(&login_body).await;
+    assert_is_redirect_to(&response, "/admin/dashboard");
+
+    // Act - Part 2 - 비밀번호를 변경한다.
+    let response = app
+        .post_change_password(&serde_json::json!({
+            "current_password": &app.test_user.password,
+            "new_password": &new_password,
+            "new_password_check": &new_password,
+        }))
+        .await;
+    assert_is_redirect_to(&response, "/admin/password");
+
+    // Act - part 3 - 리다이렉트를 따른다.
+    let html_page = app.get_change_password_html().await;
+    assert!(html_page.contains("<p><i>Your password has been changed.</i></p>"));
+
+    // Act - Part 4 - 로그아웃한다.
+    let response = app.post_logout().await;
+    assert_is_redirect_to(&response, "/login");
+
+    // Act - Part 5 - 리다이렉트를 따른다.
+    let html_page = app.get_login_html().await;
+    assert!(html_page.contains(r#"<p><i>You have successfully logged out.</i></p>"#));
+
+    // Act - Part 6 - 새로운 비밀번호를 사용해서 로그인한다.
+    let login_body = serde_json::json!({
+        "username": &app.test_user.username,
+        "password": &new_password,
+    });
+    let response = app.post_login(&login_body).await;
+    assert_is_redirect_to(&response, "/admin/dashboard");
+}

--- a/tests/api/change_password.rs
+++ b/tests/api/change_password.rs
@@ -64,3 +64,34 @@ async fn new_password_fields_must_match() {
         "<p><i>You entered two different new passwords - the field values must match.</i></p>"
     ))
 }
+
+#[tokio::test]
+async fn current_password_must_be_valid() {
+    // Arrange
+    let app = spawn_app().await;
+    let new_password = Uuid::new_v4().to_string();
+    let wrong_password = Uuid::new_v4().to_string();
+
+    // Act - Part 1 - 로그인
+    app.post_login(&serde_json::json!({
+        "username": &app.test_user.username,
+        "password": &app.test_user.password,
+    }))
+    .await;
+
+    // Act - Part 2 - 비밀번호를 변경한다.
+    let response = app
+        .post_change_password(&serde_json::json!({
+            "current_password": &wrong_password,
+            "new_password": &new_password,
+            "new_password_check": &new_password,
+        }))
+        .await;
+
+    // Assert
+    assert_is_redirect_to(&response, "/admin/password");
+
+    // Act - Part 3 - 리다이렉트를 따른다.
+    let html_page = app.get_change_password_html().await;
+    assert!(html_page.contains("<p><i>The current password is incorrect.</i></p>"));
+}

--- a/tests/api/helpers.rs
+++ b/tests/api/helpers.rs
@@ -157,6 +157,10 @@ impl TestApp {
             .expect("Failed to execute request.")
     }
 
+    pub async fn get_change_password_html(&self) -> String {
+        self.get_change_password().await.text().await.unwrap()
+    }
+
     pub async fn post_change_password<Body>(&self, body: &Body) -> reqwest::Response
     where
         Body: serde::Serialize,

--- a/tests/api/helpers.rs
+++ b/tests/api/helpers.rs
@@ -172,6 +172,14 @@ impl TestApp {
             .await
             .expect("Failed to execute request.")
     }
+
+    pub async fn post_logout(&self) -> reqwest::Response {
+        self.api_client
+            .post(&format!("{}/admin/logout", &self.address))
+            .send()
+            .await
+            .expect("Failed to execute request.")
+    }
 }
 
 pub fn assert_is_redirect_to(response: &reqwest::Response, location: &str) {

--- a/tests/api/helpers.rs
+++ b/tests/api/helpers.rs
@@ -148,6 +148,26 @@ impl TestApp {
     pub async fn get_admin_dashboard_html(&self) -> String {
         self.get_admin_dashboard().await.text().await.unwrap()
     }
+
+    pub async fn get_change_password(&self) -> reqwest::Response {
+        self.api_client
+            .get(&format!("{}/admin/password", &self.address))
+            .send()
+            .await
+            .expect("Failed to execute request.")
+    }
+
+    pub async fn post_change_password<Body>(&self, body: &Body) -> reqwest::Response
+    where
+        Body: serde::Serialize,
+    {
+        self.api_client
+            .post(&format!("{}/admin/password", &self.address))
+            .form(body)
+            .send()
+            .await
+            .expect("Failed to execute request.")
+    }
 }
 
 pub fn assert_is_redirect_to(response: &reqwest::Response, location: &str) {

--- a/tests/api/main.rs
+++ b/tests/api/main.rs
@@ -1,7 +1,8 @@
+mod admin_dashboard;
+mod change_password;
 mod health_check;
 mod helpers;
 mod login;
 mod newsletter;
 mod subscriptions;
 mod subscriptions_confirm;
-mod admin_dashboard;


### PR DESCRIPTION
최초 사용자 admin을 추가하였고, 비밀번호 변경 로직을 추가하였습니다. (초기 비밀번호는 `everythinghastostartsomewhere`)

actix-web  미들웨어를 작성하여 /admin 하위 경로 접근시 reject_anonymous_users 함수를 거치도록 구현하였습니다.
